### PR TITLE
fix typo in halOrders

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -182,7 +182,7 @@ definitions:
           href: /orders?offset=40&limit=5          
 
       _embedded:
-        order:
+        orders:
           - $ref: '#/definitions/halOrder/example'
 
   #


### PR DESCRIPTION
I think it's `orders` instead of `order` because i think in HAL collections are literally just arrays of embedded resources, maybe i'm wrong :)